### PR TITLE
Fix parallel build (with -j)

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -221,6 +221,8 @@ APP_SOURCE_PATH += $(MY_DIR)/../deps/ledger-zxlib/app/common
 SDK_SOURCE_PATH += lib_stusb lib_stusb_impl
 SDK_SOURCE_PATH  += lib_ux
 
+APP_CUSTOM_LINK_DEPENDENCIES = rust
+
 .PHONY: rust
 rust:
 	cd rust && CARGO_HOME="$(CURDIR)/rust/.cargo" cargo build --target thumbv6m-none-eabi --release


### PR DESCRIPTION
Found when comparing the Makefile with other Zondax C/Rust hybrid apps without this problem.